### PR TITLE
[fix][test] DEVBUILD-77 - Update workflows to run on self-hosted runners

### DIFF
--- a/.github/workflows/ci-documentbot.yml
+++ b/.github/workflows/ci-documentbot.yml
@@ -36,7 +36,7 @@ jobs:
     if: (github.repository == 'apache/pulsar') && (github.event.pull_request.state == 'open')
     permissions:
       pull-requests: write 
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     steps:
       - name: Labeling
         uses: apache/pulsar-test-infra/docbot@master

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   preconditions:
     name: Preconditions
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
     steps:
@@ -72,7 +72,7 @@ jobs:
     needs: preconditions
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     name: Go ${{ matrix.go-version }} Functions style check
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     strategy:
       matrix:
         go-version: [1.15, 1.16, 1.17]

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         include:
           - name: all modules
-            runs-on: ubuntu-20.04
+            runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
             cache_name: 'm2-dependencies-all'
             mvn_arguments: ''
 
@@ -67,7 +67,7 @@ jobs:
             cache_name: 'm2-dependencies-all'
 
           - name: core-modules
-            runs-on: ubuntu-20.04
+            runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
             cache_name: 'm2-dependencies-core-modules'
             mvn_arguments: '-Pcore-modules,-main'
 

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -33,7 +33,7 @@ jobs:
     env:
       JOB_NAME: Check ${{ matrix.branch }}
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   pulsarbot:
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 10
     if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/pulsarbot')
     steps:

--- a/.github/workflows/ci-stale-issue-pr.yaml
+++ b/.github/workflows/ci-stale-issue-pr.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -45,7 +45,7 @@ env:
 jobs:
   preconditions:
     name: Preconditions
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     if: (github.event_name != 'schedule') || (github.repository == 'apache/pulsar')
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
@@ -95,7 +95,7 @@ jobs:
       JOB_NAME: Flaky tests suite
       COLLECT_COVERAGE: "${{ needs.preconditions.outputs.collect_coverage }}"
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 100
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     steps:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -45,7 +45,7 @@ env:
 jobs:
   preconditions:
     name: Preconditions
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     if: (github.event_name != 'schedule') || (github.repository == 'apache/pulsar')
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
@@ -96,7 +96,7 @@ jobs:
     env:
       JOB_NAME: Build and License check
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 60
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     steps:
@@ -172,7 +172,7 @@ jobs:
       JOB_NAME: CI - Unit - ${{ matrix.name }}
       COLLECT_COVERAGE: "${{ needs.preconditions.outputs.collect_coverage }}"
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: ${{ matrix.timeout || 60 }}
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -300,7 +300,7 @@ jobs:
 
   unit-tests-upload-coverage:
     name: CI - Unit - Upload Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 30
     needs: ['preconditions', 'unit-tests']
     if: ${{ needs.preconditions.outputs.collect_coverage == 'true' }}
@@ -379,7 +379,7 @@ jobs:
 
   pulsar-java-test-image:
     name: Build Pulsar java-test-image docker image
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 60
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true'}}
@@ -451,7 +451,7 @@ jobs:
 
   integration-tests:
     name: CI - Integration - ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: ${{ matrix.timeout || 60 }}
     needs: ['preconditions', 'pulsar-java-test-image']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -606,7 +606,7 @@ jobs:
 
   integration-tests-upload-coverage:
     name: CI - Integration - Upload Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 30
     needs: ['preconditions', 'integration-tests']
     if: ${{ needs.preconditions.outputs.collect_coverage == 'true' }}
@@ -691,7 +691,7 @@ jobs:
 
   delete-integration-test-docker-image-artifact:
     name: "Delete integration test docker image artifact"
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 10
     needs: [
       'preconditions',
@@ -715,7 +715,7 @@ jobs:
 
   pulsar-test-latest-version-image:
     name: Build Pulsar docker image
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 60
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -821,7 +821,7 @@ jobs:
 
   system-tests:
     name: CI - System - ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 60
     needs: ['preconditions', 'pulsar-test-latest-version-image']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -961,7 +961,7 @@ jobs:
 
   system-tests-upload-coverage:
     name: CI - System - Upload Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 30
     needs: ['preconditions', 'system-tests']
     if: ${{ needs.preconditions.outputs.collect_coverage == 'true' }}
@@ -1047,7 +1047,7 @@ jobs:
 
   flaky-system-tests:
     name: CI Flaky - System - ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 60
     needs: [ 'preconditions', 'pulsar-test-latest-version-image' ]
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -1161,7 +1161,7 @@ jobs:
 
   delete-system-test-docker-image-artifact:
     name: "Delete system test docker image artifact"
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 10
     needs: [
       'preconditions',
@@ -1221,7 +1221,7 @@ jobs:
 
   owasp-dep-check:
     name: OWASP dependency check
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 120
     needs: [ 'preconditions', 'integration-tests' ]
     if: ${{ needs.preconditions.outputs.need_owasp == 'true' }}
@@ -1294,7 +1294,7 @@ jobs:
   pulsar-ci-checks-completed:
     name: "Pulsar CI checks completed"
     if: ${{ always() && ((github.event_name != 'schedule') || (github.repository == 'apache/pulsar')) }}
-    runs-on: ubuntu-20.04
+    runs-on: ["self-hosted", "linux", "x64", "ubuntu-2204"]
     timeout-minutes: 10
     needs: [
       'preconditions',


### PR DESCRIPTION
**Rationale:**
Workflows within this repo utilize a good amount of our organizations 3000 included minutes on a monthly basis.
This PR aims to merge in the runs-on change essentially moving the workflows over to the self-hosted solutions for testing and iteration of workflows if required.

**Risk:** 
_Moderate:_ Depending on the existing workflows in place this branch may kick those workflows off,  it's important to observe the triggered workflow's completion, any issues and the runner can be easily rolled back to a github provided solution.

**Testing:** 
Once merged workflows will require observation to ensure the self-hosted runners operate in the same manner as the github provided runners, they "should" but this is not a guarantee.

---
**Notes:**
I've observed a 3 minute wait time utilizing the self-hosted scalable solution if no warm runners are available.

More on how to utilize the self-hosted solution [here](https://hawk-eye.atlassian.net/wiki/spaces/DEVOPS/pages/3156475948/Self+Hosted+Runners+-+Github+Actions)
